### PR TITLE
Implement voice agent prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,45 @@
-# AUDIO_RAG
-AUDIO_RAG
-Hello , Begin the Project
+# AUDIO_RAG Prototype
+
+This repository contains a simple prototype of a voice agent that demonstrates
+Retrieval Augmented Generation (RAG) from audio input.
+
+## Components
+
+- `frontend/` – React Native application with a single page to record audio and
+  display the transcription and response from the backend.
+- `backend/` – FastAPI service that handles speech-to-text, vector search via
+  ChromaDB, and LLM interaction.
+
+## Setup
+
+### Backend
+
+```bash
+cd backend
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+### Frontend
+
+Requires Node.js and Expo CLI.
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+The mobile app expects the backend to run on `http://localhost:8000`.
+
+## Sample Knowledge Base
+
+Two markdown files in `backend/data/sample_kb/` are loaded into ChromaDB on
+startup. Modify or add documents there to experiment with retrieval.
+
+## Report
+
+See [`report.md`](report.md) for a short comparison of latency, quality, and
+cost considerations for different backend models.

--- a/backend/data/sample_kb/doc1.md
+++ b/backend/data/sample_kb/doc1.md
@@ -1,0 +1,1 @@
+This is the first sample document. It contains information about voice agents and how they work.

--- a/backend/data/sample_kb/doc2.md
+++ b/backend/data/sample_kb/doc2.md
@@ -1,0 +1,1 @@
+Another document discusses retrieval-augmented generation and vector databases.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,107 @@
+from fastapi import FastAPI, File, UploadFile
+from fastapi.responses import JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
+
+import uuid
+import time
+import os
+
+try:
+    import whisper
+except ImportError:
+    whisper = None
+
+try:
+    import chromadb
+    from chromadb.config import Settings
+except ImportError:
+    chromadb = None
+
+try:
+    import openai
+except ImportError:
+    openai = None
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+KB_DIR = os.path.join(os.path.dirname(__file__), "data", "sample_kb")
+CHROMA_DIR = os.path.join(os.path.dirname(__file__), "chroma_db")
+
+client = None
+collection = None
+
+@app.on_event("startup")
+def startup_event():
+    global client, collection
+    if chromadb is None:
+        print("chromadb not installed")
+        return
+    client = chromadb.Client(Settings(chroma_db_impl="duckdb+parquet", persist_directory=CHROMA_DIR))
+    collection = client.get_or_create_collection("kb")
+    ingest_kb()
+
+
+def ingest_kb():
+    if chromadb is None:
+        return
+    docs = []
+    metadatas = []
+    ids = []
+    for fname in os.listdir(KB_DIR):
+        with open(os.path.join(KB_DIR, fname), "r") as f:
+            docs.append(f.read())
+            metadatas.append({"source": fname})
+            ids.append(str(uuid.uuid4()))
+    if docs:
+        collection.add(documents=docs, metadatas=metadatas, ids=ids)
+
+
+@app.post("/query")
+async def query(audio: UploadFile = File(...)):
+    """Main RAG pipeline: audio -> text -> retrieval -> LLM"""
+    start_time = time.time()
+    if whisper is None:
+        return JSONResponse({"error": "whisper not installed"}, status_code=500)
+    # Save uploaded file
+    tmp_path = f"/tmp/{uuid.uuid4()}.wav"
+    with open(tmp_path, "wb") as f:
+        f.write(await audio.read())
+    model = whisper.load_model("base")
+    result = model.transcribe(tmp_path)
+    os.remove(tmp_path)
+    query_text = result.get("text", "")
+
+    retrieval_start = time.time()
+    if collection is not None:
+        results = collection.query(query_texts=[query_text], n_results=2)
+        contexts = [doc for doc in results.get("documents", [[]])[0]]
+    else:
+        contexts = []
+    retrieval_latency = time.time() - retrieval_start
+
+    llm_start = time.time()
+    response_text = ""
+    if openai is not None:
+        prompt = f"Answer the question based on context: {contexts}\nQuestion: {query_text}"
+        completion = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": prompt}])
+        response_text = completion.choices[0].message.content
+    else:
+        response_text = "LLM backend not configured"
+    llm_latency = time.time() - llm_start
+
+    total_latency = time.time() - start_time
+    return {
+        "transcript": query_text,
+        "response": response_text,
+        "retrieval_latency": retrieval_latency,
+        "llm_latency": llm_latency,
+        "total_latency": total_latency,
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+whisper
+chromadb
+openai

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,0 +1,1 @@
+export { default } from './src/App';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "voice-agent",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "expo start",
+    "test": "echo 'No tests'"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-native": "^0.71.0",
+    "expo": "^48.0.0",
+    "expo-av": "~13.2.1",
+    "expo-file-system": "~15.2.2"
+  },
+  "devDependencies": {
+    "typescript": "^4.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { StyleSheet, Text, View, Button } from 'react-native';
+import { Audio } from 'expo-av';
+import * as FileSystem from 'expo-file-system';
+
+export default function App() {
+  const [recording, setRecording] = useState<Audio.Recording | null>(null);
+  const [transcript, setTranscript] = useState('');
+  const [response, setResponse] = useState('');
+  const [latency, setLatency] = useState(0);
+
+  const startRecording = async () => {
+    try {
+      await Audio.requestPermissionsAsync();
+      await Audio.setAudioModeAsync({ allowsRecordingIOS: true, playsInSilentModeIOS: true });
+      const rec = new Audio.Recording();
+      await rec.prepareToRecordAsync(Audio.RECORDING_OPTIONS_PRESET_HIGH_QUALITY);
+      await rec.startAsync();
+      setRecording(rec);
+    } catch (err) {
+      console.error('Failed to start recording', err);
+    }
+  };
+
+  const stopRecording = async () => {
+    if (!recording) return;
+    await recording.stopAndUnloadAsync();
+    const uri = recording.getURI();
+    setRecording(null);
+    if (!uri) return;
+
+    const data = await FileSystem.readAsStringAsync(uri, { encoding: FileSystem.EncodingType.Base64 });
+    const start = Date.now();
+    const res = await fetch('http://localhost:8000/query', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: Buffer.from(data, 'base64'),
+    });
+    const json = await res.json();
+    setLatency(Date.now() - start);
+    setTranscript(json.transcript);
+    setResponse(json.response);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Button title={recording ? 'Stop Recording' : 'Record'} onPress={recording ? stopRecording : startRecording} />
+      <Text>Latency: {latency} ms</Text>
+      <Text>Transcript: {transcript}</Text>
+      <Text>Response: {response}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20
+  }
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "allowJs": true,
+    "noEmit": true,
+    "strict": true,
+    "target": "es2017",
+    "moduleResolution": "node"
+  }
+}

--- a/report.md
+++ b/report.md
@@ -1,0 +1,44 @@
+# Prototype Voice Agent Report
+
+This report gives a very high-level comparison of several backend options for
+transcribing audio, performing retrieval augmented generation, and producing a
+response.
+
+## Latency
+
+The prototype measures three latencies:
+
+- **Retrieval latency** – time to query ChromaDB for relevant documents.
+- **LLM latency** – time spent waiting for the language model response.
+- **Total latency** – overall time from audio upload to final text response.
+
+Exact numbers depend on hardware and model choice. Local small models will be
+slower but cost less, while hosted APIs are typically faster but incur per-call
+charges.
+
+## Quality / Accuracy
+
+- Whisper provides good transcription accuracy for English speech.
+- Retrieval quality depends on the relevance of documents in ChromaDB and the
+  embedding model used.
+- Using larger language models usually yields more coherent answers but costs
+  more and may have higher latency.
+
+## Cost Estimates
+
+- **OpenAI GPT-3.5**: priced per token (see OpenAI pricing). Each request may
+  cost a fraction of a cent depending on prompt and response length.
+- **Local models**: once downloaded, no per-call cost beyond compute time.
+- **ChromaDB**: open-source and free to run locally.
+
+## Architecture Justification
+
+- **FastAPI** offers a lightweight Python backend with async support.
+- **ChromaDB** is used for the vector store due to its easy setup and local
+  persistence.
+- **Expo/React Native** allows quick iteration of a cross-platform mobile UI for
+  capturing audio.
+
+Scaling this prototype would require moving the vector database and model
+inference to managed services or more robust infrastructure. Caching of frequent
+queries and batching can help reduce costs.


### PR DESCRIPTION
## Summary
- add FastAPI backend for speech to text, retrieval, and LLM
- add sample knowledge base documents indexed with ChromaDB
- add React Native frontend to capture audio and display results
- document setup and architecture
- provide short report comparing latency, quality, and costs

## Testing
- `pytest` *(no tests found)*
- `npm test --silent` in `frontend` *(prints "No tests")*

------
https://chatgpt.com/codex/tasks/task_e_6851fcad306083329046782f3b3b4c99